### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ shadowJar {
 
 run {
     standardInput = System.in
+    enableAssertions = true
 }
 
 checkstyle {

--- a/src/main/java/carbon/utils/Ui.java
+++ b/src/main/java/carbon/utils/Ui.java
@@ -52,6 +52,7 @@ public class Ui {
                         String.format("The command \"%s\" is not recognised", mostRecentCommand));
             };
         } catch (InvalidCommandException | InvalidArgumentException e) {
+            assert !e.getMessage().isBlank() : "Exception should have a message";
             return formatError(e.getMessage());
         } catch (NumberFormatException e) {
             return formatError(String.format("I expected a single integer after \"%s\"", mostRecentCommand));


### PR DESCRIPTION
The current codebase does not utilise assertions, and gradle has assertions disabled by default.

Assertions are useful to ensure the control flow and overall logic of the program is as intended.

Let's add assertions to verify program logic, and update the gradle configuration to enable assertions.