### PR TITLE
TaskList.java: Make Stream clearer

### DIFF
--- a/src/main/java/carbon/task/TaskList.java
+++ b/src/main/java/carbon/task/TaskList.java
@@ -1,7 +1,6 @@
 package carbon.task;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -57,15 +56,20 @@ public class TaskList {
         if (tasks.isEmpty()) {
             return "You don't have any tasks! :)";
         }
-        List<String> results = IntStream.range(0, tasks.size())
+
+        return IntStream.range(0, tasks.size())
                 .filter(i -> tasks.get(i).toString().toLowerCase().contains(filter.toLowerCase()))
                 .mapToObj(i -> (i + 1) + ". " + tasks.get(i))
-                .toList();
-        boolean isPlural = results.size() != 1;
-        return results.isEmpty()
-                ? String.format("You don't have any tasks that contain \"%s\".", filter)
-                : String.format("%d task%s contain%s \"%s\":\n", results.size(), isPlural ? "s" : "",
-                isPlural ? "" : "s", filter) + String.join("\n", results);
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        results -> results.isEmpty()
+                                ? String.format("You don't have any tasks that contain \"%s\".", filter)
+                                : String.format("%d task%s contain%s \"%s\":\n",
+                                results.size(),
+                                results.size() != 1 ? "s" : "",
+                                results.size() == 1 ? "s" : "",
+                                filter) + String.join("\n", results)
+                ));
     }
 
     /**


### PR DESCRIPTION
The Stream in the listTasks method of TaskList.java is closed early due to a processing step that relies on the number of filtered tasks.

Combining that step into the streaming process allows for more readable code.

Let's refactor this section to improve readability.